### PR TITLE
chore: reduce CLS on home page (add w/h to sponsors svg)

### DIFF
--- a/.vitepress/theme/components/HomePage.vue
+++ b/.vitepress/theme/components/HomePage.vue
@@ -67,6 +67,8 @@ const actions: ButtonData[] = [{
             <a href="https://github.com/sponsors/cyberalien" target="_blank" rel="noopener noreferrer" title="Support Iconify!">
               <img
                 crossorigin="anonymous"
+                width="800"
+                height="288"
                 class="resizable-img"
                 loading="lazy"
                 src="https://cyberalien.github.io/static/sponsors.svg"


### PR DESCRIPTION
Light house results using mobile:

![imagen](https://user-images.githubusercontent.com/6311119/237057609-c580c3ed-74e0-46e1-8d23-ebbe9b07b20b.png)
