### PR TITLE
update Icon import path

### DIFF
--- a/docs/usage/svg/astro/index.md
+++ b/docs/usage/svg/astro/index.md
@@ -27,7 +27,7 @@ Astro Icon can inline SVG directly in your HTML:
 
 ```astro
 ---
-import { Icon } from 'astro-icon'
+import { Icon } from 'astro-icon/components'
 ---
 
 <Icon name="mdi:home" />


### PR DESCRIPTION
The icon previous icon import path was not working and in the astroicon.dev website it was 'import { Icon } from 'astro-icon/components'; which worked.