### PR TITLE
docs: fix code snippet for clean Tailwind 3 plugin

### DIFF
--- a/docs/usage/css/tailwind/tailwind3/index.md
+++ b/docs/usage/css/tailwind/tailwind3/index.md
@@ -43,7 +43,7 @@ hint: "Usage with addDynamicIconSelectors"
 ```
 
 ```yaml
-src: usage/tailwind/syntax-iconify.html
+src: usage/tailwind/syntax-iconify2.html
 hint: "Usage with addIconSelectors"
 ```
 


### PR DESCRIPTION
Current docs show the same usage code snippet for clean plugin (`addIconSelectors`) and for dynamic plugin (`addDynamicIconSelectors`). This commit fixes the code snippet for clean plugin by reusing the snippet from docs for Tailwind v4.