### PR TITLE
Update Astro Icon usage documentation

### DIFF
--- a/docs/usage/svg/astro/index.md
+++ b/docs/usage/svg/astro/index.md
@@ -23,7 +23,13 @@ npm i -D astro-icon
 
 ## Usage
 
-Astro Icon can inline SVG directly in your HTML:
+After choosing your desired icon set, ensure you install it into your Astro project - preferrably as a dev dependency. For example, let us choose the Material Design iconset.
+
+```sh
+npm i -D @iconify-json/mdi
+```
+
+Astro Icon can now inline SVG directly in your HTML:
 
 ```astro
 ---


### PR DESCRIPTION
Added a required (but missing) installation instruction for using an iconify icon set.

While it is mentioned in the [@astro-icon docs](https://github.com/natemoo-re/astro-icon?tab=readme-ov-file#iconify-icons), it would be more convenient for users to read it directly from here (if they were already on this page).